### PR TITLE
Update action to build new version of image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-        - "8.13.0"
+        - "8.17.0"
         include:
-        - version: "8.13.0"
+        - version: "8.17.0"
           latest: true
 
     steps:


### PR DESCRIPTION
Fix [action](https://github.com/swaglive/docker-vips/actions/runs/15756303257/job/44412408641) as the version is overwritten by the action.